### PR TITLE
Add aarch64 version for arm laboratory skel.

### DIFF
--- a/laborator/lab-arm64/skel/1-install-toolchain/Makefile
+++ b/laborator/lab-arm64/skel/1-install-toolchain/Makefile
@@ -1,0 +1,15 @@
+AS=aarch64-linux-gnu-as
+LD=aarch64-linux-gnu-ld
+CC=aarch64-linux-gnu-gcc -static
+
+L_PATH=/opt/gcc-aarch64/aarch64-linux-gnu/libc/
+
+build:
+	@$(AS) helloworld.asm -o helloworld.o
+	@$(LD) -o hello helloworld.o
+
+run: build
+	@qemu-aarch64 -L $(L_PATH) hello || true
+
+clean:
+	rm -f helloworld.o hello

--- a/laborator/lab-arm64/skel/1-install-toolchain/helloworld.asm
+++ b/laborator/lab-arm64/skel/1-install-toolchain/helloworld.asm
@@ -1,0 +1,13 @@
+.global _start
+_start:
+    mov x2, #14
+    ldr x1, =string
+    mov x8, #64
+    svc 0
+    mov x8, #93
+    svc 0
+    
+.data
+string:
+    .ascii "Hello, World!"
+    .byte 10, 0

--- a/laborator/lab-arm64/skel/1-install-toolchain/install_toolchain.sh
+++ b/laborator/lab-arm64/skel/1-install-toolchain/install_toolchain.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TARGET_DIR="/opt/gcc-aarch64/"
+LINK="https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz"
+
+echo "downloading the toolchain to $TARGET_DIR. There are ~100MB to download..."
+mkdir -p $TARGET_DIR
+wget -qO- $LINK | tar xJ -C $TARGET_DIR --strip-components=1
+
+if [[ -z $(grep "$TARGET_DIR" ~/.bashrc) ]]; then
+	echo "updating the PATH variable..."
+	echo 'export PATH=$PATH'":$TARGET_DIR/bin" >> ~/.bashrc
+	source ~/.bashrc
+fi

--- a/laborator/lab-arm64/skel/2-mul-sum/Makefile
+++ b/laborator/lab-arm64/skel/2-mul-sum/Makefile
@@ -1,0 +1,15 @@
+AS=aarch64-linux-gnu-as
+LD=aarch64-linux-gnu-ld
+CC=aarch64-linux-gnu-gcc -static
+
+L_PATH=/opt/gcc-aarch64/aarch64-linux-gnu/libc/
+
+build:
+	@$(AS) mul.asm -o mul.o
+	@$(CC) -o mul mul.o
+
+run: build
+	@qemu-aarch64  -L $(L_PATH) mul || true
+
+clean:
+	rm -f mul.o mul

--- a/laborator/lab-arm64/skel/2-mul-sum/mul.asm
+++ b/laborator/lab-arm64/skel/2-mul-sum/mul.asm
@@ -1,0 +1,25 @@
+.global main
+main:
+    // prologue
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0
+
+    // initialization
+    mov x0, #10     // n
+    eor x1, x1, x1  // sum
+    mov x2, #1      // current number
+
+    // TODO Compute sum of squares; place result in x1
+
+    // print result
+    ldr x0, =output
+    bl printf
+
+    // epilogue
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+
+.data
+output:
+  .asciz "%d\n"

--- a/laborator/lab-arm64/skel/3-mem-addr/Makefile
+++ b/laborator/lab-arm64/skel/3-mem-addr/Makefile
@@ -1,0 +1,15 @@
+AS=aarch64-linux-gnu-as
+LD=aarch64-linux-gnu-ld
+CC=aarch64-linux-gnu-gcc -static
+
+L_PATH=/opt/gcc-aarch64/aarch64-linux-gnu/libc/
+
+build:
+	@$(AS) mem.asm -o mem.o
+	@$(CC) -o mem mem.o
+
+run: build
+	@qemu-aarch64 -L $(L_PATH) mem || true
+
+clean:
+	rm -f mem.o mem

--- a/laborator/lab-arm64/skel/3-mem-addr/mem.asm
+++ b/laborator/lab-arm64/skel/3-mem-addr/mem.asm
@@ -1,0 +1,27 @@
+.global main
+main: 
+    // prologue
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0 
+
+    ldr x19, =nums
+    ldr w1, [x19]
+
+    // print result
+    ldr x0, =output
+    bl printf
+
+    // epilogue
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+
+.data
+nums:
+  .byte 5, 2, -3, 7, 8
+
+nums_size:
+  .byte 5
+
+output:
+  .asciz "%d\n"

--- a/laborator/lab-arm64/skel/4-flags/Makefile
+++ b/laborator/lab-arm64/skel/4-flags/Makefile
@@ -1,0 +1,15 @@
+AS=aarch64-linux-gnu-as
+LD=aarch64-linux-gnu-ld
+CC=aarch64-linux-gnu-gcc -static
+
+L_PATH=/opt/gcc-aarch64/aarch64-linux-gnu/libc/
+
+build:
+	@$(AS) flags.asm -o flags.o
+	@$(CC) -o flags flags.o
+
+run: build
+	@qemu-aarch64 -L $(L_PATH) flags || true
+
+clean:
+	rm -f flags.o flags

--- a/laborator/lab-arm64/skel/4-flags/flags.asm
+++ b/laborator/lab-arm64/skel/4-flags/flags.asm
@@ -1,0 +1,25 @@
+.global main
+main:
+    // prologue
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0 
+
+    mov x0, #0
+    mov x1, #2
+
+    sub x3, x1, x0
+    b.eq exit
+
+    // print result
+    ldr x0, =output
+    bl printf
+
+exit:
+    // epilogue
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+
+.data
+output:
+  .asciz "Nothing special here\n"

--- a/laborator/lab-arm64/skel/5-strings/Makefile
+++ b/laborator/lab-arm64/skel/5-strings/Makefile
@@ -1,0 +1,15 @@
+AS=aarch64-linux-gnu-as
+LD=aarch64-linux-gnu-ld
+CC=aarch64-linux-gnu-gcc -static
+
+L_PATH=/opt/gcc-aarch64/aarch64-linux-gnu/libc/
+
+build:
+	@$(AS) strings.asm -o strings.o
+	@$(CC) -o strings strings.o
+
+run: build
+	@qemu-aarch64 -L $(L_PATH) strings || true
+
+clean:
+	rm -f strings.o strings

--- a/laborator/lab-arm64/skel/5-strings/strings.asm
+++ b/laborator/lab-arm64/skel/5-strings/strings.asm
@@ -1,0 +1,72 @@
+.global main
+main:
+    // prologue
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0 
+
+    // pretty print
+    ldr x0, =printlen
+    bl printf
+
+    // TODO 1: call strlen
+
+    // TODO 1: call printf to print result of strlen
+
+    // print occurences pretty string
+    ldr x0, =printocr
+    bl printf
+
+    // TODO 3: call substr
+    
+    // epilogue
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+
+// TODO 1: implement strlen
+strlen:
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0
+
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+
+
+// TODO 2: implement starts_with
+starts_with:
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0
+
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ret
+    
+
+
+// TODO 3: implement substr
+substr:
+    stp x0, x1, [sp, #-16]!
+    stp x29, x30, [sp, #-16]!
+    add x29, sp, #0 
+
+   
+    sub sp, x29, #0
+    ldp x29, x30, [sp], #16
+    ldp x0, x1, [sp], #16
+    ret
+
+
+.data
+subs:
+  .asciz "is"
+output:
+  .asciz "%d\n"
+chr:
+  .asciz "%c\n"
+printlen:
+  .asciz "String length is:\n"
+printocr:
+  .asciz "Substring appears at positions:\n"
+string:
+  .asciz "This string is the bomb"


### PR DESCRIPTION
This pull request contains necessary Makefiles, source code and scripts for an aarch64 lab, similar to the old arm one.

I've added the "-static" flag in every Makefile, in order to avoid the problem described at [1]. The alternative would be to include download commands for ld-linux-aarch64.so in the install_toolchain script.

I will send the solutions for the private iocla repository to @razvand.

[1] https://ughe.github.io/2018/07/19/qemu-aarch64